### PR TITLE
Ignore CPY001 missing-copyright-notice ruff rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ ignore = [
 
   # Overly burdensome
   "ANN", # flake8-annotations
+  "CPY001", # missing-copyright-notice
   "D1", # undocumented-*
   "EM", # flake8-errmsg
   "ERA001", # commented-out-code


### PR DESCRIPTION
Adds `CPY001` (missing-copyright-notice) to the ruff lint ignore list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)